### PR TITLE
Fixes herberttn/bytenode-webpack-plugin#5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "bytenode": "^1.2.2",
     "slash": "3.0.0",
-    "webpack-virtual-modules": "^0.4.2"
+    "webpack-virtual-modules": "^0.4.3"
   },
   "peerDependencies": {
     "webpack": "4.x"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "webpack-virtual-modules": "^0.4.3"
   },
   "peerDependencies": {
-    "webpack": "4.x"
+    "webpack": ">= 4.0 < 6"
   },
   "devDependencies": {
     "@jest/types": "26.6.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:watch": "npm run test -- --watch"
   },
   "dependencies": {
-    "bytenode": "^1.2.2",
+    "bytenode": "^1.3.3",
     "slash": "3.0.0",
     "webpack-virtual-modules": "^0.4.3"
   },


### PR DESCRIPTION
Webpack 5 seems to pass through entrypoint paths with a more complex data structure, e.g. in an Electron context:
`[{
  main_window: {
    import: ['./src/index.ts']
  }
}]`

Whereas the plugin would expect:
`[{ main_window: './src/index.ts' }]`

These commits add in some extra data manipulation to give the plugin the file paths as expected.

Todo:
- [ ] Dig out the Webpack docs/spec to ensure these fixes are compatible with all potential entry inputs
- [ ] Test extensively with more than just an electron-forge + TS + Webpack template app