### PR TITLE
fix: require `bytenode` before require of `.jsc` file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,7 +97,9 @@ class BytenodeWebpackPlugin implements WebpackPluginInstance {
           const replace = `(.*)${file}(.*)`;
           const rex = new RegExp(replace,"g");
           const matches = rex.exec(raw)
-          raw = raw.replace(matches![0], `require('bytenode'); ${matches![1]}${name}${matches![2]}`)
+          if (matches) {
+            raw = raw.replace(matches![0], `require('bytenode'); ${matches![1]}${name}${matches![2]}`)
+          }
         }
         return raw;
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,11 @@ class BytenodeWebpackPlugin implements WebpackPluginInstance {
 
       const source = await replaceSource(asset, raw => {
         for (const file of files) {
-          raw = raw.replace(file, fromTargetToCompiledExtension(file));
+          const name = fromTargetToCompiledExtension(file)
+          const replace = `(.*)${file}(.*)`;
+          const rex = new RegExp(replace,"g");
+          const matches = rex.exec(raw)
+          raw = raw.replace(matches![0], `require('bytenode'); ${matches![1]}${name}${matches![2]}`)
         }
         return raw;
       });


### PR DESCRIPTION
Using regex to force `require` bytenode before webpack's custom require of `.jsc`.

Verified this works for a single-file-entry configuration, I'm not sure about more complex file configurations. If it doesn't work, then we'll know right away since `matches![0]` is a force-unwrap of an array that could be null (if no regex matches). I think we can assume there will always be a regex match since it's just selecting the line with the file's name

Fixes: #12
