### PR TITLE
fix(examples): squirrel description is required

### DIFF
--- a/examples/electron-forge-typescript-webpack/package.json
+++ b/examples/electron-forge-typescript-webpack/package.json
@@ -46,7 +46,8 @@
         {
           "name": "@electron-forge/maker-squirrel",
           "config": {
-            "name": "electron_forge_typescript_webpack"
+            "name": "electron_forge_typescript_webpack",
+            "description": "electron-forge-typescript-webpack-example"
           }
         },
         {

--- a/examples/electron-forge-webpack/package.json
+++ b/examples/electron-forge-webpack/package.json
@@ -37,7 +37,8 @@
         {
           "name": "@electron-forge/maker-squirrel",
           "config": {
-            "name": "electron_forge_webpack"
+            "name": "electron_forge_webpack",
+            "description": "electron_forge_webpack"
           }
         },
         {


### PR DESCRIPTION
An error occured while making for target: squirrel Failed with exit code: 1
Output:
Attempting to build package from 'electron_forge_typescript_webpack.nuspec'. Description is required.