### PR TITLE
Won't compile for preload entry without other assets

### DIFF
--- a/examples/electron-forge-typescript-webpack/forge.config.ts
+++ b/examples/electron-forge-typescript-webpack/forge.config.ts
@@ -27,8 +27,25 @@ const config: ForgeConfig = {
             js: './src/renderer.ts',
             name: 'main_window',
             preload: {
-              config: preloadConfig,
+              config: {
+                ...preloadConfig,
+                entry: {
+                  preload: './src/preload.ts',
+                },
+              },
               js: './src/preload.ts',
+            },
+          },
+          {
+            name: 'frame',
+            preload: {
+              config: {
+                ...preloadConfig,
+                entry: {
+                  preload: './src/frame_preload.ts',
+                },
+              },
+              js: './src/frame_preload.ts',
             },
           },
         ],

--- a/examples/electron-forge-typescript-webpack/src/frame_preload.ts
+++ b/examples/electron-forge-typescript-webpack/src/frame_preload.ts
@@ -1,0 +1,3 @@
+console.log(
+  '🍕 This message is being logged by "src/frame_preload.ts", included via webpack.'
+);

--- a/examples/electron-forge-typescript-webpack/webpack.preload.config.ts
+++ b/examples/electron-forge-typescript-webpack/webpack.preload.config.ts
@@ -4,9 +4,6 @@ import { rules } from './webpack.shared.rules';
 import { plugins } from './webpack.shared.plugins';
 
 const preloadConfig: Configuration = {
-  entry: {
-    preload: './src/preload.ts',
-  },
   module: {
     rules,
   },


### PR DESCRIPTION
Plugin will throw `Error: webpack.options.output.filename cannot be static, use a dynamic one like [name].js` for preload entries without other assets like `html` and `ts`